### PR TITLE
Feat: reconnect websocket and wait before resolving connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "base64url": "^2.0.0",
     "btp-packet": "^1.2.0",
     "debug": "^3.1.0",
+    "eventemitter2": "^5.0.0",
     "ws": "^3.3.3"
   },
   "devDependencies": {

--- a/test/scripts/test.js
+++ b/test/scripts/test.js
@@ -11,9 +11,6 @@ const client = new BtpPlugin({
 })
 
 async function run () {
-  /*await server.connect()
-  await client.connect()*/
-
   await Promise.all([
     server.connect(),
     client.connect()

--- a/test/scripts/test.js
+++ b/test/scripts/test.js
@@ -11,8 +11,13 @@ const client = new BtpPlugin({
 })
 
 async function run () {
-  await server.connect()
-  await client.connect()
+  /*await server.connect()
+  await client.connect()*/
+
+  await Promise.all([
+    server.connect(),
+    client.connect()
+  ])
 
   server.registerDataHandler((ilp) => {
     console.log('server got:', IlpPacket.deserializeIlpPacket(ilp))

--- a/ws-reconnect.js
+++ b/ws-reconnect.js
@@ -1,0 +1,41 @@
+const WebSocket = require('ws')
+const debug = require('debug')('websocket-wrapper')
+const EventEmitter2 = require('eventemitter2')
+const DEFAULT_RECONNECT_INTERVAL = 5000
+
+class WebSocketWrapper extends EventEmitter2 {
+  constructor () {
+    super()
+    this._interval = 5000
+  }
+
+  open (url) {
+    this._url = url
+    this._instance = new WebSocket(this._url)
+    this._instance.on('open', () => void this.emit('open'))
+    this._instance.on('close', (code) => this._reconnect(code))
+    this._instance.on('error', (err) => this._reconnect(err.code))
+    this._instance.on('message', (data, flags) => void this.emit('message', data, flags))
+  }
+
+  // uses callback to match normal ws api
+  send (data, callback) {
+    return this._instance.send(data, callback)
+  }
+
+  _reconnect (code) {
+    debug(`websocket disconnected with ${code}; reconnect in ${this._interval}`)
+    this._connected = false
+    this._instance.removeAllListeners()
+    setTimeout(() => {
+      this.open(this._url)
+    }, this._interval)
+  }
+
+  close () {
+    this._instance.removeAllListeners()
+    return this._instance.close()
+  }
+}
+
+module.exports = WebSocketWrapper

--- a/ws-reconnect.js
+++ b/ws-reconnect.js
@@ -3,10 +3,10 @@ const debug = require('debug')('websocket-wrapper')
 const EventEmitter2 = require('eventemitter2')
 const DEFAULT_RECONNECT_INTERVAL = 5000
 
-class WebSocketWrapper extends EventEmitter2 {
-  constructor () {
+class WebSocketReconnector extends EventEmitter2 {
+  constructor ({ interval }) {
     super()
-    this._interval = 5000
+    this._interval = interval || 5000
   }
 
   open (url) {
@@ -38,4 +38,4 @@ class WebSocketWrapper extends EventEmitter2 {
   }
 }
 
-module.exports = WebSocketWrapper
+module.exports = WebSocketReconnector


### PR DESCRIPTION
This PR aims to make connect/disconnect logic in the BTP plugin more robust. The changes should be localized to the connect and disconnect functions, so plugins which inherit and change the connection logic shouldn't have any issues. Furthermore, plugins which override only `_connect` and `_disconnect` should not have to change.

The server now doesn't resolve `connect` until a client has connected. Similarly, the client doesn't resolve until it has connected to the server. The client will continue trying to connect every 5 seconds if it fails to connect. This means that a server/client pair can be started in any order, and will resolve to a stable state.