### PR TITLE
fix: export types correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+'use strict'
+module.exports = require('./src').default
+module.exports.default = module.exports

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "ilp-plugin-btp",
   "version": "1.1.13",
   "description": "Generic BTP plugin for ILP",
-  "main": "src/index.js",
+  "main": "index.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "mocha ./test/index.test.js",


### PR DESCRIPTION
Also changes `_connect` and `_disconnect` to protected methods, since other plugins will inherit from `AbstractBtpPlugin` and overwrite them.

These changes are needed for `ilp-plugin-mini-accounts` to be rewritten in typescript.