### PR TITLE
fix: client should clean up timers on connect fail 

### DIFF
--- a/src/ws-reconnect.ts
+++ b/src/ws-reconnect.ts
@@ -43,6 +43,7 @@ export class WebSocketReconnector extends EventEmitter2 {
   private _intervals: Array<number>
   private _clearTryTimeout: number
   private _clearTryTimer?: NodeJS.Timer
+  private _openTimer?: NodeJS.Timer
   private _tries: number
 
   /**
@@ -110,6 +111,9 @@ export class WebSocketReconnector extends EventEmitter2 {
     this._instance.removeAllListeners()
     this.emit('close')
     this._instance.close()
+
+    if (this._openTimer) clearTimeout(this._openTimer)
+    if (this._clearTryTimer) clearTimeout(this._clearTryTimer)
   }
 
   /**
@@ -122,7 +126,7 @@ export class WebSocketReconnector extends EventEmitter2 {
     debug.debug(`websocket disconnected with ${codeOrError}; reconnect in ${this._intervals[this._tries]}}`)
     this._connected = false
     this._instance.removeAllListeners()
-    setTimeout(() => {
+    this._openTimer = setTimeout(() => {
       void this.open(this._url)
     }, this._intervals[this._tries])
     this._tries = Math.min(this._tries + 1, this._intervals.length - 1)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -141,6 +141,20 @@ describe('BtpPlugin', function () {
       }, /account\/token must be passed in via constructor or uri, but not both/)
     })
 
+    it('throws if the client auth is incorrect', async function () {
+      this.client = new Plugin({ server: 'btp+ws://bob:wrong_secret@localhost:9000' })
+      await Promise.all([
+        this.server.connect(),
+        this.client.connect()
+      ]).then(() => {
+        assert(false)
+      }).catch((err) => {
+        assert.equal(err.message, 'connection aborted')
+      })
+      assert.strictEqual(this.server.isConnected(), false)
+      assert.strictEqual(this.client.isConnected(), false)
+    })
+
     it('connects the client and server', async function () {
       this.client = new Plugin({
         server: 'btp+ws://localhost:9000',


### PR DESCRIPTION
If a client `connect()` aborts, close the `WebSocketReconnector` and clear its timers so that it doesn't keep retrying in the background.

Also correctly log an authentication error so that it doesn't trigger `UnhandledPromiseRejectionWarning`.