### PR TITLE
Use build directory for js and avoid tsc on npm install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,21 +11,21 @@ defaults: &defaults
 
 jobs:
   test:
-    <<: *defaults  
+    <<: *defaults
     steps:
 
       - run:
           # By default node is installed as root and we are running as circleci
           # Using sudo causes wierd issues so we just switch to installing globals in our home dir
           name: Setup NPM to make global installs to home directory
-          command: | 
+          command: |
             echo "export PATH=$HOME/bin:$PATH" >> $BASH_ENV
             npm set prefix=$HOME
 
       - checkout
 
       - restore_cache:
-          keys: 
+          keys:
             # when lock file changes, use increasingly general patterns to restore cache
             - "node-v1-{{ .Branch }}-{{ checksum \"package-lock.json\" }}"
             - "node-v1-{{ .Branch }}-"
@@ -38,7 +38,7 @@ jobs:
       - run:
           name: Update Lockfile (Greenkeeper)
           command: greenkeeper-lockfile-update
-          
+
       - run:
           name: Install
           command: npm install
@@ -46,6 +46,9 @@ jobs:
       - run:
           name: Lint
           command: npm run lint
+      - run:
+          name: Build
+          command: npm run build
 
       - run:
           name: Test
@@ -54,7 +57,7 @@ jobs:
 #      - run:
 #          name: Integration Test
 #          command: if git log -1 --pretty=%B | grep -qF "[skip tests]"; then true; else npm run integration; fi
-     
+
       - run:
           name: Upload Lockfile (Greenkeeper)
           command: greenkeeper-lockfile-upload
@@ -78,7 +81,7 @@ jobs:
       - run:
           name: Publish package
           command: npm publish
-            
+
 workflows:
   version: 2
   test-deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 node_modules/
-/src/*.js
-/src/*.js.map
-/src/*.d.ts
+build
+
+# Output of 'npm pack'
+*.tgz
+# dotenv environment variables file
+.env

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 'use strict'
-module.exports = require('./src').default
+module.exports = require('./build').default
 module.exports.default = module.exports

--- a/package.json
+++ b/package.json
@@ -3,25 +3,20 @@
   "version": "1.3.3",
   "description": "Generic BTP plugin for ILP",
   "main": "index.js",
-  "types": "src/index.d.ts",
+  "types": "build/index.d.ts",
+  "files": [
+    "build/**/*"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/interledgerjs/ilp-plugin-btp.git"
   },
   "scripts": {
-    "build": "tsc",
-    "test": "mocha ./test/index.test.js",
-    "prepare": "npm run build",
-    "pretest": "npm run build",
     "lint": "tslint --project .",
+    "build": "tsc --project .",
+    "test": "mocha ./test/index.test.js",
     "codecov": "codecov"
   },
-  "files": [
-    "src/*.js",
-    "src/*.js.map",
-    "src/*.ts",
-    "src/*.d.ts"
-  ],
   "author": "Interledger Team <info@interledger.org>",
   "license": "Apache-2.0",
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2017",
     "module": "commonjs",
     "declaration": true,
     "noImplicitAny": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,13 @@
     "sourceMap": true,
     "inlineSources": true,
     "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true
+    "suppressImplicitAnyIndexErrors": true,
+    "rootDir": "./src",
+    "outDir": "./build"
   },
+  "include": [
+    "src/**/*"
+  ],
   "types": [],
   "compileOnSave": true
 }


### PR DESCRIPTION
When building plugins, differences in tsconfig (particularly use of `strict`) can cause installing btp to fail on otherwise successful builds. With this commit, npm publish will only include `build` files and avoid `tsc` when installing btp from npm. 