### PR TITLE
feat: optional http health check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -952,6 +952,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
+      "dev": true
+    },
     "normalize-url": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "codecov": "^3.0.0",
     "gh-pages": "^1.1.0",
     "mocha": "^5.1.1",
+    "node-fetch": "^2.3.0",
     "source-map-support": "^0.5.0",
     "ts-node": "^7.0.1",
     "tslint": "^5.8.0",

--- a/test/helpers/mockSocket.js
+++ b/test/helpers/mockSocket.js
@@ -43,7 +43,8 @@ class OutgoingSocket extends EventEmitter {
 }
 
 class Server extends EventEmitter {
-  constructor ({port}) {
+  // mock server constructor parameters mirror those found in https://github.com/websockets/ws/blob/master/doc/ws.md
+  constructor ({ host, port, backlog, server, verifyClient, handleProtocols, path, noServer, clientTracking, perMessageDeflate, maxPayload }, cb) {
     super()
     this.closed = false
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,6 +8,7 @@ const fetch = require('node-fetch')
 const http = require('http')
 
 describe('BtpPlugin', function () {
+
   beforeEach(async function () {
     this.clientOpts = {
       server: 'btp+ws://bob:secret@localhost:9000',


### PR DESCRIPTION
Kubernetes's ingress uses availability checks to make sure the endpoints that it routes traffic towards are indeed available. Because these checks use http(s), an http server must actually be responding with affirmatives (e.g. `200 OK`). Fortunately, the websocket library used in this plugin can take in a `server` option, such that it may provide websocket connections as it always has, and additionally serve http responses as well.