### PR TITLE
feat: better in-browser support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:8.11.3
+    - image: circleci/node:10
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Generic BTP plugin for ILP",
   "main": "index.js",
   "types": "build/index.d.ts",
+  "browser": {
+    "crypto": "./src/browser/crypto.ts"
+  },
   "files": [
     "build/**/*"
   ],
@@ -42,5 +45,8 @@
     "tslint-config-standard": "^7.0.0",
     "typedoc": "^0.12.0",
     "typescript": "^3.0.1"
+  },
+  "engines": {
+    "node": ">=10.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "types": "build/index.d.ts",
   "browser": {
-    "crypto": "./src/browser/crypto.ts"
+    "crypto": "./src/browser/crypto.ts",
+    "ws": "./src/browser/ws.ts"
   },
   "files": [
     "build/**/*"

--- a/src/browser/crypto.ts
+++ b/src/browser/crypto.ts
@@ -1,0 +1,13 @@
+// Note: this polyfill doesn't include `crypto.timingSafeEqual()`. The browser
+// never runs a BTP server, so it doesn't need to compare tokens.
+
+const { crypto } = window
+
+export function randomBytes (
+  size: number,
+  callback: (err: Error | null, buf: Buffer) => void
+): void {
+  const randArray = new Uint8Array(size)
+  const randValues = crypto.getRandomValues(randArray)
+  callback(null, Buffer.from(randValues))
+}

--- a/src/browser/ws.ts
+++ b/src/browser/ws.ts
@@ -1,0 +1,40 @@
+import { EventEmitter } from 'events'
+
+class WebSocketPolyfill extends EventEmitter {
+  private _ws: WebSocket
+  constructor (uri: string) {
+    super()
+    this._ws = new WebSocket(uri)
+    this._ws.binaryType = 'arraybuffer'
+    this._ws.onerror = this.emit.bind(this, 'error')
+    this._ws.onopen = this.emit.bind(this, 'open')
+    this._ws.onclose = this.emit.bind(this, 'close')
+    this._ws.onmessage = (msg) => {
+      this.emit('message', Buffer.from(msg.data))
+    }
+  }
+
+  send (msg: Buffer, cb: (err?: Error) => void) {
+    if (this._ws.readyState === WebSocket.CONNECTING || this._ws.readyState === WebSocket.OPEN) {
+      this._ws.send(msg.buffer)
+      process.nextTick(cb)
+    } else {
+      process.nextTick(cb, new Error('already closed'))
+    }
+  }
+
+  /**
+   * This does not seem necessary to implement:
+   * see: https://github.com/interledgerjs/ilp-plugin-btp/commit/9975a2129f55fe57a16686beb66c22363ffbea7f#diff-7890877dd7f005f29976f46177e3e756R142
+   * see: https://github.com/websockets/ws/blob/master/lib/sender.js#L47
+   * see: https://github.com/websockets/ws/blob/master/lib/sender.js#L173
+   */
+  // tslint:disable-next-line:no-empty
+  ping () {}
+
+  close () {
+    this._ws.close()
+  }
+}
+
+export = WebSocketPolyfill

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import * as http from 'http'
 import * as https from 'https'
 import { WebSocketReconnector, WebSocketConstructor } from './ws-reconnect'
 import { EventEmitter2, Listener } from 'eventemitter2'
-import { URL } from 'url'
 import { protocolDataToIlpAndCustom, ilpAndCustomToProtocolData } from './protocol-data-converter'
 
 const BtpPacket = require('btp-packet')

--- a/src/ws-reconnect.ts
+++ b/src/ws-reconnect.ts
@@ -151,7 +151,7 @@ export class WebSocketReconnector extends EventEmitter2 {
    * between reconnect to clean up old listeners.
    */
   private _reconnect (codeOrError: number | Error) {
-    debug.debug(`websocket disconnected with ${codeOrError}; reconnect in ${this._intervals[this._tries]}}`)
+    debug.debug(`websocket disconnected with ${codeOrError}; reconnect in ${this._intervals[this._tries]}`)
     this._connected = false
     this._instance.removeAllListeners()
     this._openTimer = setTimeout(() => {


### PR DESCRIPTION
* Don't try to import `URL` (which is a global in Node `>=10.0.0` and in the browser).
* Use WebCrypto to generate random bytes so that a crypto polyfill isn't needed.