### PR TITLE
fix(browser url):

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,14 @@ const namesToCodes = {
   'InsufficientBalanceError': 'F08'
 }
 
+const toBrowserSafeURL = (btpUrl: string): string => {
+  if (!btpUrl.startsWith('btp+')) {
+    throw new Error('server must start with "btp+". server=' + this._server)
+  }
+
+  return btpUrl.substring(4)
+}
+
 /**
  * Returns BTP error code as defined by the BTP ASN.1 spec.
  */
@@ -246,13 +254,11 @@ export default class AbstractBtpPlugin extends EventEmitter2 {
     }
 
     if (this._server) {
-      const parsedBtpUri = new URL(this._server)
+      const browserSafeUrl = toBrowserSafeURL(this._server)
+      const parsedBtpUri = new URL(browserSafeUrl)
       const parsedAccount = parsedBtpUri.username
       const parsedToken = parsedBtpUri.password
 
-      if (!parsedBtpUri.protocol.startsWith('btp+')) {
-        throw new Error('server must start with "btp+". server=' + this._server)
-      }
 
       if ((parsedAccount || parsedToken) && (options.btpAccount || options.btpToken)) {
         throw new Error('account/token must be passed in via constructor or uri, but not both')
@@ -386,7 +392,8 @@ export default class AbstractBtpPlugin extends EventEmitter2 {
 
     /* Client logic. */
     if (this._server) {
-      const parsedBtpUri = new URL(this._server)
+      const browserSafeUrl = toBrowserSafeURL(this._server)
+      const parsedBtpUri = new URL(browserSafeUrl)
       const account = this._btpAccount || ''
       const token = this._btpToken || ''
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,12 +36,12 @@ const namesToCodes = {
   'InsufficientBalanceError': 'F08'
 }
 
-const toBrowserSafeURL = (btpUrl: string): string => {
+const toBrowserSafeURL = (btpUrl: string): URL => {
   if (!btpUrl.startsWith('btp+')) {
     throw new Error('server must start with "btp+". server=' + btpUrl)
   }
 
-  return btpUrl.substring(4)
+  return new URL(btpUrl.substring(4))
 }
 
 /**
@@ -254,8 +254,7 @@ export default class AbstractBtpPlugin extends EventEmitter2 {
     }
 
     if (this._server) {
-      const browserSafeUrl = toBrowserSafeURL(this._server)
-      const parsedBtpUri = new URL(browserSafeUrl)
+      const parsedBtpUri = toBrowserSafeURL(this._server)
       const parsedAccount = parsedBtpUri.username
       const parsedToken = parsedBtpUri.password
 
@@ -391,8 +390,7 @@ export default class AbstractBtpPlugin extends EventEmitter2 {
 
     /* Client logic. */
     if (this._server) {
-      const browserSafeUrl = toBrowserSafeURL(this._server)
-      const parsedBtpUri = new URL(browserSafeUrl)
+      const parsedBtpUri = toBrowserSafeURL(this._server)
       const account = this._btpAccount || ''
       const token = this._btpToken || ''
 
@@ -434,9 +432,8 @@ export default class AbstractBtpPlugin extends EventEmitter2 {
       // of removing the 'user@pass:' part from parsedBtpUri.toString()!
       parsedBtpUri.username = ''
       parsedBtpUri.password = ''
-      const wsUri = parsedBtpUri.toString().substring('btp+'.length)
 
-      await this._ws.open(wsUri)
+      await this._ws.open(parsedBtpUri.toString())
 
       this._ws.on('close', () => this._emitDisconnect())
       this._ws.on('message', this._handleIncomingWsMessage.bind(this, this._ws))

--- a/src/index.ts
+++ b/src/index.ts
@@ -259,7 +259,6 @@ export default class AbstractBtpPlugin extends EventEmitter2 {
       const parsedAccount = parsedBtpUri.username
       const parsedToken = parsedBtpUri.password
 
-
       if ((parsedAccount || parsedToken) && (options.btpAccount || options.btpToken)) {
         throw new Error('account/token must be passed in via constructor or uri, but not both')
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ const namesToCodes = {
 
 const toBrowserSafeURL = (btpUrl: string): string => {
   if (!btpUrl.startsWith('btp+')) {
-    throw new Error('server must start with "btp+". server=' + this._server)
+    throw new Error('server must start with "btp+". server=' + btpUrl)
   }
 
   return btpUrl.substring(4)


### PR DESCRIPTION
Currently the browser URL library doesn't handle custom protocols correctly. This was discovered whilst @sublimator and I were trying to get this working in the browser

`URL("btp+ws://")`
![image](https://user-images.githubusercontent.com/12172996/65753986-66af4680-e110-11e9-9427-bada78fa537a.png)

`URL("ws://")`
![image (1)](https://user-images.githubusercontent.com/12172996/65753990-6911a080-e110-11e9-8b49-a3e6a6249445.png)

This PR just make sure to use a helper function to convert the URL from `this._server` to a browserSafe version before using it

