### PR TITLE
fix(crypto): replace window object with self for service workers

### DIFF
--- a/src/browser/crypto.ts
+++ b/src/browser/crypto.ts
@@ -1,7 +1,7 @@
 // Note: this polyfill doesn't include `crypto.timingSafeEqual()`. The browser
 // never runs a BTP server, so it doesn't need to compare tokens.
 
-const { crypto } = window
+const { crypto } = self
 
 export function randomBytes (
   size: number,


### PR DESCRIPTION
Replaced the window object with `self` as the window object is not present in service workers.